### PR TITLE
206 Backend env not updating with new frontend env config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,8 @@ services:
     environment:
       MONGO_INITDB_ROOT_USERNAME: admin
       MONGO_INITDB_ROOT_PASSWORD: password
+    env_file:
+      - .env
     volumes:
       - mongodb_data:/data/db
     networks:
@@ -114,8 +116,6 @@ services:
       - ./.env:/.env:rw
       - ./docker-compose.yml:/docker-compose.yml:ro
       - /var/run/docker.sock:/var/run/docker.sock
-    env_file:
-      - .env
     depends_on:
       - mongodb
     networks:


### PR DESCRIPTION
- Move the `env_file` docker compose config to mongo service so we still get the required error but not the issue with the restarted backend containers not updating with new env vars.